### PR TITLE
Add custom slash commands tip to Claude Code post

### DIFF
--- a/_posts/2025-06-16-claude-code-tips.md
+++ b/_posts/2025-06-16-claude-code-tips.md
@@ -54,6 +54,13 @@ Claude Code has headless mode for non-interactive environments like CI, pre-comm
 - `claude commit`: Create a Git commit, co-authored by Claude
 - `claude -r`: Resume the previous conversation
 
+### Custom Slash Commands
+You can create your own slash commands as Markdown files to build reusable prompts:
+- **Project commands**: Store in `.claude/commands/` to share with your team
+- **Personal commands**: Store in `~/.claude/commands/` for personal use across projects
+- Use `$ARGUMENTS` placeholder for dynamic content, and reference files with `@` prefix
+- Example: Create `.claude/commands/optimize.md` with "Analyze this code for performance issues: $ARGUMENTS" and use with `/optimize myfile.js`
+
 ## Links
 
 - [Claude Code Best Practices](https://www.anthropic.com/engineering/claude-code-best-practices)


### PR DESCRIPTION
## Summary
- Added a new section about custom slash commands to the Claude Code tips blog post
- Covers project vs personal commands, storage locations, and usage examples

## Test plan
- [x] Content added to existing blog post
- [x] Formatting and markdown syntax verified

🤖 Generated with [Claude Code](https://claude.ai/code)